### PR TITLE
Fix `make test` build on ubuntu

### DIFF
--- a/lib/camel/makefile
+++ b/lib/camel/makefile
@@ -16,7 +16,7 @@ setup:
 
 ./target/libcamel.a: target-dir ./target/tuwi.o ./camel.h ./src/camel.c
 	$(CC) $(CFLAGS) -c ./src/camel.c -o ./target/camel.o
-	ar rcs ./target/libcamel.a ./target/camel.o ./target/tuwi.o ../netlibc/target/netlibc.o
+	ar rcs ./target/libcamel.a ./target/camel.o ./target/tuwi.o ../netlibc/target/netlibc.a
 
 ./target/tuwi.o:
 	cd ../tuwi/ && make

--- a/lib/camel/makefile
+++ b/lib/camel/makefile
@@ -16,7 +16,7 @@ setup:
 
 ./target/libcamel.a: target-dir ./target/tuwi.o ./camel.h ./src/camel.c
 	$(CC) $(CFLAGS) -c ./src/camel.c -o ./target/camel.o
-	ar rcs ./target/libcamel.a ./target/camel.o ./target/tuwi.o
+	ar rcs ./target/libcamel.a ./target/camel.o ./target/tuwi.o ../netlibc/target/netlibc.o
 
 ./target/tuwi.o:
 	cd ../tuwi/ && make

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -70,7 +70,7 @@ target-dir:
 	mkdir -p $(TARGET_DIR)
 
 setup-linux:
-	sudo apt install build-essential libssl-dev uuid-dev pkgconf
+	sudo apt install build-essential libssl-dev uuid-dev pkgconf clang
 
 
 # LIBRARIES


### PR DESCRIPTION
The build for test was failing due to missing symbols from netlibc