### PR TITLE
Fixes and UX improvement

### DIFF
--- a/src/docs/md/docs.md
+++ b/src/docs/md/docs.md
@@ -328,7 +328,7 @@ When a node receives a new version of an existing profile and verifies that it w
 For example, if you change some code in a code repository, you have to republish your entire profile.
 Nodes that pin that profile will then replace their copy of the profile with the new one.
 
-<div id="#how-to-use-shoggoth"></div>
+<div id="how-to-use-shoggoth"></div>
 
 ## How to use Shoggoth - Overview
 
@@ -350,7 +350,7 @@ The below command starts a Shoggoth node:
 shog node run
 ```
 
-<div id="#creating-and-publishing-a-profile"></div>
+<div id="creating-and-publishing-a-profile"></div>
 
 ### Creating and Publishing a Profile
 
@@ -385,14 +385,14 @@ then run the below command to publish it:
 shog client publish
 ```
 
-<div id="#updating-modifying-a-profile"></div>
+<div id="updating-modifying-a-profile"></div>
 
 #### Updating/Modifying a Profile
 
 To update or modify your profile, change the content of the `shoggoth-profile` folder on your local machine, then publish the profile again.
 When a node receives your new profile, it simply replaces the old one with the new one. Since your profile is a folder, you can simply drag and drop or copy files into it, then run the publish command again to update your profile on the network.
 
-<div id="#downloading-profiles-and-resources"></div>
+<div id="downloading-profiles-and-resources"></div>
 
 ### Downloading Profiles and Resources
 

--- a/src/explorer/static/docs/docs.css
+++ b/src/explorer/static/docs/docs.css
@@ -5,10 +5,10 @@ body {
 }
 
 pre {
-	margin-top: 20px;
-	margin-bottom: 20px;
-	
-	overflow-x: auto;
+  margin-top: 20px;
+  margin-bottom: 20px;
+
+  overflow-x: auto;
   width: 100%;
 }
 
@@ -21,7 +21,8 @@ tr {
   border: 2px solid gray;
 }
 
-td, th {
+td,
+th {
   text-align: left;
   padding: 8px;
   border: 2px solid gray;
@@ -53,7 +54,7 @@ h4 {
   margin-bottom: 5px;
 }
 
-p { 
+p {
   margin-top: 20px;
   margin-bottom: 10px;
   line-height: 160%;
@@ -63,7 +64,7 @@ code {
   padding: 4px;
   padding-top: 2px;
   padding-bottom: 2px;
-  
+
   background: #333;
   border-radius: 8px;
   max-width: 80vw;
@@ -89,6 +90,7 @@ code {
 
 .table-of-contents {
   color: white;
+  margin: 0 auto;
 }
 
 .table-of-contents h2 {
@@ -105,4 +107,3 @@ code {
   margin-left: 40px;
   list-style-type: none;
 }
-

--- a/src/explorer/static/docs/docs.css
+++ b/src/explorer/static/docs/docs.css
@@ -107,3 +107,21 @@ code {
   margin-left: 40px;
   list-style-type: none;
 }
+
+.scroll-to-top {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+}
+
+.scroll-to-top a {
+  background-color: #863e00;
+  color: #fff;
+  padding: 10px 15px;
+  border-radius: 5px;
+  text-decoration: none;
+}
+
+.scroll-to-top a:hover {
+  background-color: #5f2d00;
+}

--- a/src/explorer/templates/table_of_contents.html
+++ b/src/explorer/templates/table_of_contents.html
@@ -1,4 +1,4 @@
-<div class="table-of-contents">
+<div class="table-of-contents" id="table-of-contents">
     <h2>Table of Contents</h2>
     <ul>
         <li><a href="#what-is-shoggoth">What is Shoggoth?</a></li>
@@ -49,4 +49,7 @@
         <li><a href="#dependencies">Dependencies</a></li>
         <li><a href="#donate">Donate, Sponsor Shoggoth</a></li>
     </ul>
+    <div class="scroll-to-top">
+        <a href="#table-of-contents">Back to Top</a>
+    </div>
 </div>

--- a/src/explorer/templates/table_of_contents.html
+++ b/src/explorer/templates/table_of_contents.html
@@ -42,7 +42,7 @@
         <li><a href="#configuration">Configuration</a></li>
         <li><a href="#api">Node HTTP API</a></li>
         <li><a href="#explorer">Shoggoth Explorer</a></li>
-        <li><a href="exposing-a-shoggoth-node-to-the-internet">Exposing a Shoggoth Node to the Internet</a></li>
+        <li><a href="#exposing-a-shoggoth-node-to-the-internet">Exposing a Shoggoth Node to the Internet</a></li>
         <li><a href="#system-requirements">System Requirements</a></li>
         <li><a href="#contributing">Contributing to Shoggoth</a></li>
         <li><a href="#faq">Frequently Asked Questions</a></li>


### PR DESCRIPTION
This PR contains the following:

1. Fixed docs.md -> It contained wrong div ids which prevented the table of contents from navigating to the specific sections

2. Table of contents styling -> Added style to have the table of contents always at the center of the screen for better UX

3. Back to Top button -> This button allows the user to quickly navigate back and forward between the table of contents and the sections it redirects to

Image of the current state of the table of contents with this PR, notice the "Back to Top" button below. 

![Screenshot 2023-11-08 220227](https://github.com/thenetrunna/shoggoth/assets/86041666/30f47c97-71d5-4491-87ee-4f4c3940d59a)
